### PR TITLE
remove tab name from pathname

### DIFF
--- a/components/profile/data/Data.tsx
+++ b/components/profile/data/Data.tsx
@@ -3,16 +3,17 @@ import EventList from "./tabs/events/EventList";
 import Tabs from "./tabs/Tabs";
 import SectionTitle from "../SectionTitle";
 import { useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 const Data = () => {
-  const searchParams = useSearchParams();
-  const currTab = searchParams.get("tab");
-
+  // const searchParams = useSearchParams();
+  // const currTab = searchParams.get("tab");
+  const [currTab, setCurrTab] = useState<'quotes' | 'events'>('quotes')
   // todo: populate it with the profile user
   return (
     <div className="relative mt-10">
       <SectionTitle title="Data" />
-      <Tabs />
+      <Tabs currTab={currTab} setCurrTab={setCurrTab} />
       {currTab === "quotes" || currTab === null ? <QuoteList /> : <EventList />}
     </div>
   );

--- a/components/profile/data/Data.tsx
+++ b/components/profile/data/Data.tsx
@@ -6,15 +6,13 @@ import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 const Data = () => {
-  // const searchParams = useSearchParams();
-  // const currTab = searchParams.get("tab");
-  const [currTab, setCurrTab] = useState<'quotes' | 'events'>('quotes')
-  // todo: populate it with the profile user
+  const [currTab, setCurrTab] = useState<"quotes" | "events">("quotes");
+
   return (
     <div className="relative mt-10">
       <SectionTitle title="Data" />
       <Tabs currTab={currTab} setCurrTab={setCurrTab} />
-      {currTab === "quotes" || currTab === null ? <QuoteList /> : <EventList />}
+      {currTab === "quotes" ? <QuoteList /> : <EventList />}
     </div>
   );
 };

--- a/components/profile/data/tabs/Tabs.tsx
+++ b/components/profile/data/tabs/Tabs.tsx
@@ -1,12 +1,17 @@
 import { useEvent } from "@/context/EventContext";
 import { useQuote } from "@/context/QuoteContext";
 import { ProfileTabs } from "@/types/type";
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { capitalizeFirstLetter } from "@/functions/capitalizeFirstLetter";
 import { twMerge } from "tailwind-merge";
 
-const Tabs = () => {
+type Props = {
+  currTab: "quotes" | "events";
+  setCurrTab: Dispatch<SetStateAction<"quotes" | "events">>;
+};
+
+const Tabs = ({currTab, setCurrTab}: Props) => {
   const { profileUserQuotes } = useQuote();
   const { profileUserEvents } = useEvent();
 
@@ -15,14 +20,14 @@ const Tabs = () => {
     { name: "events", length: profileUserEvents.length },
   ];
 
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const currTab = searchParams.get("tab");
+  // const router = useRouter();
+  // const pathname = usePathname();
+  // const searchParams = useSearchParams();
+  // const currTab = searchParams.get("tab");
 
-  const handleClick = (val: string) => {
-    router.push(pathname + `?tab=${val}`);
-  };
+  // const handleClick = (val: string) => {
+  //   router.push(pathname + `?tab=${val}`);
+  // };
 
   return (
     <div className="flex items-stretch">
@@ -35,7 +40,11 @@ const Tabs = () => {
               ? "rounded-2xl bg-violet-50 text-violet-500 dark:bg-slate-900 dark:text-white"
               : ""
           )}
-          onClick={() => handleClick(tab.name)}
+          onClick={() => {
+            if (tab.name === 'quotes') setCurrTab(tab.name)
+            else if (tab.name === 'events') setCurrTab(tab.name)
+          }}
+          // onClick={() => handleClick(tab.name)}
         >
           {capitalizeFirstLetter(tab.name)}
         </span>

--- a/components/profile/data/tabs/Tabs.tsx
+++ b/components/profile/data/tabs/Tabs.tsx
@@ -20,15 +20,6 @@ const Tabs = ({currTab, setCurrTab}: Props) => {
     { name: "events", length: profileUserEvents.length },
   ];
 
-  // const router = useRouter();
-  // const pathname = usePathname();
-  // const searchParams = useSearchParams();
-  // const currTab = searchParams.get("tab");
-
-  // const handleClick = (val: string) => {
-  //   router.push(pathname + `?tab=${val}`);
-  // };
-
   return (
     <div className="flex items-stretch">
       {tabs.map((tab) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - プロフィールページにおいて、現在のタブをReactの`useState`フックを使用して直接検索パラメーターから取得するのではなく、更新する機能を追加しました。この変更により、より良い状態管理と現在のタブ選択の制御が可能になります。
    - `Tabs`コンポーネントが`currTab`と`setCurrTab`をプロップスとして受け入れるようになり、現在のタブの内部状態管理を置き換えました。タブ切り替え用の`handleClick`関数はコメントアウトされ、代わりに`onClick`イベントハンドラ内で直接現在のタブの状態を更新するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->